### PR TITLE
Pin to opensearch-ruby to version 1

### DIFF
--- a/.github/workflows/2.4.yml
+++ b/.github/workflows/2.4.yml
@@ -25,7 +25,7 @@ jobs:
         sudo sysctl -w vm.swappiness=1
         sudo sysctl -w fs.file-max=262144
         sudo sysctl -w vm.max_map_count=262144
-    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@main
+    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
         cluster-version: latest
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/2.4.yml
+++ b/.github/workflows/2.4.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
-        cluster-version: latest
+        cluster-version: 1.3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.4

--- a/.github/workflows/2.4.yml
+++ b/.github/workflows/2.4.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
-        cluster-version: 1.3
+        cluster-version: 1
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.4

--- a/.github/workflows/2.5.yml
+++ b/.github/workflows/2.5.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
-        cluster-version: 1.3
+        cluster-version: 1
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5

--- a/.github/workflows/2.5.yml
+++ b/.github/workflows/2.5.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
-        cluster-version: latest
+        cluster-version: 1.3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5

--- a/.github/workflows/2.5.yml
+++ b/.github/workflows/2.5.yml
@@ -25,7 +25,7 @@ jobs:
         sudo sysctl -w vm.swappiness=1
         sudo sysctl -w fs.file-max=262144
         sudo sysctl -w vm.max_map_count=262144
-    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@main
+    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
         cluster-version: latest
     - uses: ruby/setup-ruby@v1
@@ -44,4 +44,4 @@ jobs:
       run: cd opensearch-persistence && bundle exec rake test:all
     - name: Test opensearch-model
       run: cd opensearch-model && bundle exec rake test:all
-        
+

--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
-        cluster-version: latest
+        cluster-version: 1.3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6

--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -25,7 +25,7 @@ jobs:
         sudo sysctl -w vm.swappiness=1
         sudo sysctl -w fs.file-max=262144
         sudo sysctl -w vm.max_map_count=262144
-    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@main
+    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
         cluster-version: latest
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
-        cluster-version: 1.3
+        cluster-version: 1
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6

--- a/.github/workflows/2.7.yml
+++ b/.github/workflows/2.7.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
-        cluster-version: latest
+        cluster-version: 1.3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7

--- a/.github/workflows/2.7.yml
+++ b/.github/workflows/2.7.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
-        cluster-version: 1.3
+        cluster-version: 1
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7

--- a/.github/workflows/2.7.yml
+++ b/.github/workflows/2.7.yml
@@ -25,7 +25,7 @@ jobs:
         sudo sysctl -w vm.swappiness=1
         sudo sysctl -w fs.file-max=262144
         sudo sysctl -w vm.max_map_count=262144
-    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@main
+    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
         cluster-version: latest
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
-        cluster-version: latest
+        cluster-version: 1.3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: jruby-9.3

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -27,7 +27,7 @@ jobs:
         sudo sysctl -w vm.max_map_count=262144
     - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
-        cluster-version: 1.3
+        cluster-version: 1
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: jruby-9.3

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -25,7 +25,7 @@ jobs:
         sudo sysctl -w vm.swappiness=1
         sudo sysctl -w fs.file-max=262144
         sudo sysctl -w vm.max_map_count=262144
-    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@main
+    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
       with:
         cluster-version: latest
     - uses: ruby/setup-ruby@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+* Pin opensearch-ruby to '~> 1.1' because OpenSearch 2 is not supported yet
+
 ## 0.1.0
 
 * Fork [elasticsearch-rails v7.2.1](https://github.com/elastic/elasticsearch-rails/tree/v7.2.1)

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@
 source 'https://rubygems.org'
 
 gem "rake", "~> 12"
-gem "opensearch-ruby"
+gem "opensearch-ruby", '~> 1.0'
 gem "pry"
 gem "ansi"
 gem "cane"

--- a/opensearch-model/lib/opensearch/model/version.rb
+++ b/opensearch-model/lib/opensearch/model/version.rb
@@ -17,6 +17,6 @@
 
 module OpenSearch
   module Model
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/opensearch-model/opensearch-model.gemspec
+++ b/opensearch-model/opensearch-model.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'activesupport', '> 3'
-  s.add_dependency "opensearch-ruby"
+  s.add_dependency "opensearch-ruby", '~> 1.0'
   s.add_dependency 'hashie'
 
   s.add_development_dependency 'activemodel', '> 3'

--- a/opensearch-persistence/examples/notes/Gemfile
+++ b/opensearch-persistence/examples/notes/Gemfile
@@ -25,7 +25,7 @@ gem 'oj'
 gem 'hashie'
 
 gem 'patron'
-gem 'opensearch-ruby'
+gem 'opensearch-ruby', '~> 1.0'
 gem 'opensearch-model',       git: 'https://github.com/compliance-innovations/opensearch-rails.git'
 gem 'opensearch-persistence', git: 'https://github.com/compliance-innovations/opensearch-rails.git'
 

--- a/opensearch-persistence/lib/opensearch/persistence/version.rb
+++ b/opensearch-persistence/lib/opensearch/persistence/version.rb
@@ -17,6 +17,6 @@
 
 module OpenSearch
   module Persistence
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/opensearch-persistence/opensearch-persistence.gemspec
+++ b/opensearch-persistence/opensearch-persistence.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_dependency "opensearch-ruby"
+  s.add_dependency "opensearch-ruby", '~> 1.0'
   s.add_dependency "opensearch-model"
   s.add_dependency "activesupport",       '> 4'
   s.add_dependency "activemodel",         '> 4'

--- a/opensearch-rails/lib/opensearch/rails/version.rb
+++ b/opensearch-rails/lib/opensearch/rails/version.rb
@@ -17,6 +17,6 @@
 
 module OpenSearch
   module Rails
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/opensearch-rails/lib/rails/templates/01-basic.rb
+++ b/opensearch-rails/lib/rails/templates/01-basic.rb
@@ -156,7 +156,7 @@ puts
 say_status  "Rubygems", "Adding OpenSearch libraries into Gemfile...\n", :yellow
 puts        '-'*80, ''; sleep 0.75
 
-gem 'opensearch-ruby'
+gem 'opensearch-ruby', '~> 1.0'
 gem 'opensearch-model', git: 'https://github.com/compliance-innovations/opensearch-rails.git'
 gem 'opensearch-rails', git: 'https://github.com/compliance-innovations/opensearch-rails.git'
 


### PR DESCRIPTION
Currently, the `opensearch-rails` gem is not yet compatible with OpenSearch 2 due to the [removal of the mapping types parameter](https://opensearch.org/docs/2.0/breaking-changes/#200). Hence, the gem is not compatible yet with version 2 of `opensearch-ruby`. The gemspec file did not specify a specific `opensearch-ruby` version. With this pull request we pin `opensearch-ruby` to version `~> 1.1` for now.