### PR TITLE
Support OpenSearch 2 by removing deprecated mapping types

### DIFF
--- a/.github/workflows/2.4.yml
+++ b/.github/workflows/2.4.yml
@@ -25,9 +25,9 @@ jobs:
         sudo sysctl -w vm.swappiness=1
         sudo sysctl -w fs.file-max=262144
         sudo sysctl -w vm.max_map_count=262144
-    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
+    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@main
       with:
-        cluster-version: 1
+        cluster-version: 2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.4

--- a/.github/workflows/2.5.yml
+++ b/.github/workflows/2.5.yml
@@ -25,9 +25,9 @@ jobs:
         sudo sysctl -w vm.swappiness=1
         sudo sysctl -w fs.file-max=262144
         sudo sysctl -w vm.max_map_count=262144
-    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
+    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@main
       with:
-        cluster-version: 1
+        cluster-version: 2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5

--- a/.github/workflows/2.6.yml
+++ b/.github/workflows/2.6.yml
@@ -25,9 +25,9 @@ jobs:
         sudo sysctl -w vm.swappiness=1
         sudo sysctl -w fs.file-max=262144
         sudo sysctl -w vm.max_map_count=262144
-    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
+    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@main
       with:
-        cluster-version: 1
+        cluster-version: 2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6

--- a/.github/workflows/2.7.yml
+++ b/.github/workflows/2.7.yml
@@ -25,9 +25,9 @@ jobs:
         sudo sysctl -w vm.swappiness=1
         sudo sysctl -w fs.file-max=262144
         sudo sysctl -w vm.max_map_count=262144
-    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
+    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@main
       with:
-        cluster-version: 1
+        cluster-version: 2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -25,9 +25,9 @@ jobs:
         sudo sysctl -w vm.swappiness=1
         sudo sysctl -w fs.file-max=262144
         sudo sysctl -w vm.max_map_count=262144
-    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@1.x
+    - uses: opensearch-project/opensearch-ruby/.github/actions/opensearch@main
       with:
-        cluster-version: 1
+        cluster-version: 2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: jruby-9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+* Support OpenSearch 2 by removing deprecated type and include_type_name parameters
+
 ## 0.1.1
 
 * Pin opensearch-ruby to '~> 1.1' because OpenSearch 2 is not supported yet

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@
 source 'https://rubygems.org'
 
 gem "rake", "~> 12"
-gem "opensearch-ruby", '~> 1.0'
+gem "opensearch-ruby", '~> 2.0'
 gem "pry"
 gem "ansi"
 gem "cane"

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ The libraries are compatible with Ruby 2.4 and higher.
 
 We follow Ruby’s own maintenance policy and officially support all currently maintained versions per [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/).
 
-The version numbers follow the OpenSearch major versions. Currently the `main` branch is compatible with version `1.x` of the OpenSearch stack.
+The version numbers follow the OpenSearch major versions. Currently the `main` branch is compatible with version `2.x` of the OpenSearch stack.
 
 | Rubygem       |   | OpenSearch    |
 |:-------------:|:-:| :-----------: |
-| main          | → | 1.x           |
+| main          | → | 2.x           |
 
 ## Usage
 

--- a/opensearch-model/README.md
+++ b/opensearch-model/README.md
@@ -12,7 +12,7 @@ The library version numbers follow the OpenSearch major versions. The `main` bra
 
 | Rubygem       |   | OpenSearch    |
 |:-------------:|:-:| :-----------: |
-| main          | → | 1.x           |
+| main          | → | 2.x           |
 
 ## Installation
 

--- a/opensearch-model/README.md
+++ b/opensearch-model/README.md
@@ -523,10 +523,10 @@ class Indexer
     case operation.to_s
       when /index/
         record = Article.find(record_id)
-        Client.index  index: 'articles', type: 'article', id: record.id, body: record.__opensearch__.as_indexed_json
+        Client.index  index: 'articles', id: record.id, body: record.__opensearch__.as_indexed_json
       when /delete/
         begin
-          Client.delete index: 'articles', type: 'article', id: record_id
+          Client.delete index: 'articles', id: record_id
         rescue OpenSearch::Transport::Transport::Errors::NotFound
           logger.debug "Article not found, ID: #{record_id}"
         end

--- a/opensearch-model/examples/activerecord_article.rb
+++ b/opensearch-model/examples/activerecord_article.rb
@@ -64,7 +64,6 @@ client = OpenSearch::Client.new log:true
 
 client.indices.delete index: 'articles' rescue nil
 client.bulk index: 'articles',
-            type:  'article',
             body:  Article.all.as_json.map { |a| { index: { _id: a.delete('id'), data: a } } },
             refresh: true
 

--- a/opensearch-model/examples/couchbase_article.rb
+++ b/opensearch-model/examples/couchbase_article.rb
@@ -70,13 +70,12 @@ client = OpenSearch::Client.new log:true
 
 client.indices.delete index: 'articles' rescue nil
 client.bulk index: 'articles',
-            type:  'article',
             body:  Article.find(['1', '2', '3']).map { |a|
                      { index: { _id: a.id, data: a.attributes } }
                    },
             refresh: true
 
-response = Article.search 'foo', index: 'articles', type: 'article';
+response = Article.search 'foo', index: 'articles';
 
 Pry.start(binding, prompt: lambda { |obj, nest_level, _| '> ' },
                    input: StringIO.new('response.records.to_a'),

--- a/opensearch-model/examples/mongoid_article.rb
+++ b/opensearch-model/examples/mongoid_article.rb
@@ -70,7 +70,6 @@ client = OpenSearch::Client.new host:'localhost:9200', log:true
 
 client.indices.delete index: 'articles' rescue nil
 client.bulk index: 'articles',
-            type:  'article',
             body:  Article.all.map { |a| { index: { _id: a.id, data: a.attributes } } },
             refresh: true
 

--- a/opensearch-model/examples/ohm_article.rb
+++ b/opensearch-model/examples/ohm_article.rb
@@ -75,7 +75,6 @@ Article.create id: '3', title: 'Foo Foo'
 
 Article.__opensearch__.client.indices.delete index: 'articles' rescue nil
 Article.__opensearch__.client.bulk index: 'articles',
-                                      type:  'article',
                                       body:  Article.all.map { |a| { index: { _id: a.id, data: a.attributes } } },
                                       refresh: true
 

--- a/opensearch-model/examples/riak_article.rb
+++ b/opensearch-model/examples/riak_article.rb
@@ -56,7 +56,6 @@ client = OpenSearch::Client.new log:true
 
 client.indices.delete index: 'articles' rescue nil
 client.bulk index: 'articles',
-            type:  'article',
             body:  Article.all.map { |a|
                      { index: { _id: a.key, data: JSON.parse(a.robject.raw_data) } }
                    }.as_json,

--- a/opensearch-model/lib/opensearch/model/importing.rb
+++ b/opensearch-model/lib/opensearch/model/importing.rb
@@ -99,9 +99,9 @@ module OpenSearch
         #
         #    Article.import refresh: true
         #
-        # @example Import the records into a different index/type than the default one
+        # @example Import the records into a different index than the default one
         #
-        #    Article.import index: 'my-new-index', type: 'my-other-type'
+        #    Article.import index: 'my-new-index'
         #
         # @example Pass an ActiveRecord scope to limit the imported records
         #
@@ -141,7 +141,6 @@ module OpenSearch
           errors       = []
           refresh      = options.delete(:refresh)   || false
           target_index = options.delete(:index)     || index_name
-          target_type  = options.delete(:type)      || document_type
           transform    = options.delete(:transform) || __transform
           pipeline     = options.delete(:pipeline)
           return_value = options.delete(:return)    || 'count'
@@ -161,7 +160,6 @@ module OpenSearch
           __find_in_batches(options) do |batch|
             params = {
               index: target_index,
-              type:  target_type,
               body:  __batch_to_bulk(batch, transform)
             }
 

--- a/opensearch-model/lib/opensearch/model/indexing.rb
+++ b/opensearch-model/lib/opensearch/model/indexing.rb
@@ -51,13 +51,12 @@ module OpenSearch
       # Wraps the [index mappings](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html)
       #
       class Mappings
-        attr_accessor :options, :type
+        attr_accessor :options
 
         # @private
         TYPES_WITH_EMBEDDED_PROPERTIES = %w(object nested)
 
-        def initialize(type = nil, options={})
-          @type    = type
+        def initialize(options={})
           @options = options
           @mapping = {}
         end
@@ -87,11 +86,7 @@ module OpenSearch
         end
 
         def to_hash
-          if @type
-            { @type.to_sym => @options.merge( properties: @mapping ) }
-          else
-            @options.merge( properties: @mapping )
-          end
+          @options.merge( properties: @mapping )
         end
 
         def as_json(options={})
@@ -152,7 +147,7 @@ module OpenSearch
         # when it doesn't already define them. Use the `__opensearch__` proxy otherwise.
         #
         def mapping(options={}, &block)
-          @mapping ||= Mappings.new(document_type, options)
+          @mapping ||= Mappings.new(options)
 
           @mapping.options.update(options) unless options.empty?
 
@@ -372,7 +367,6 @@ module OpenSearch
           request = { index: index_name,
                       id:    id,
                       body:  document }
-          request.merge!(type: document_type) if document_type
 
           client.index(request.merge!(options))
         end
@@ -393,7 +387,6 @@ module OpenSearch
         def delete_document(options={})
           request = { index: index_name,
                       id:    self.id }
-          request.merge!(type: document_type) if document_type
 
           client.delete(request.merge!(options))
         end
@@ -434,7 +427,6 @@ module OpenSearch
               request = { index: index_name,
                           id:    self.id,
                           body:  { doc: attributes } }
-              request.merge!(type: document_type) if document_type
 
               client.update(request.merge!(options))
             end
@@ -461,7 +453,6 @@ module OpenSearch
           request = { index: index_name,
                       id:    self.id,
                       body:  { doc: attributes } }
-          request.merge!(type: document_type) if document_type
 
           client.update(request.merge!(options))
         end

--- a/opensearch-model/lib/opensearch/model/searching.rb
+++ b/opensearch-model/lib/opensearch/model/searching.rb
@@ -37,7 +37,6 @@ module OpenSearch
           @options = options
 
           __index_name    = options[:index] || klass.index_name
-          __document_type = options[:type]  || klass.document_type
 
           case
             # search query: ...
@@ -54,9 +53,9 @@ module OpenSearch
           end
 
           if body
-            @definition = { index: __index_name, type: __document_type, body: body }.update options
+            @definition = { index: __index_name, body: body }.update options
           else
-            @definition = { index: __index_name, type: __document_type, q: q }.update options
+            @definition = { index: __index_name, q: q }.update options
           end
         end
 
@@ -71,7 +70,7 @@ module OpenSearch
 
       module ClassMethods
 
-        # Provides a `search` method for the model to easily search within an index/type
+        # Provides a `search` method for the model to easily search within an index
         # corresponding to the model settings.
         #
         # @param query_or_payload [String,Hash,Object] The search request definition

--- a/opensearch-model/lib/opensearch/model/version.rb
+++ b/opensearch-model/lib/opensearch/model/version.rb
@@ -17,6 +17,6 @@
 
 module OpenSearch
   module Model
-    VERSION = "0.1.1"
+    VERSION = "1.0.0"
   end
 end

--- a/opensearch-model/opensearch-model.gemspec
+++ b/opensearch-model/opensearch-model.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'activesupport', '> 3'
-  s.add_dependency "opensearch-ruby", '~> 1.0'
+  s.add_dependency "opensearch-ruby", '~> 2.0'
   s.add_dependency 'hashie'
 
   s.add_development_dependency 'activemodel', '> 3'

--- a/opensearch-model/spec/opensearch/model/adapters/active_record/basic_spec.rb
+++ b/opensearch-model/spec/opensearch/model/adapters/active_record/basic_spec.rb
@@ -160,17 +160,6 @@ describe OpenSearch::Model::Adapter::ActiveRecord do
       end
     end
 
-    describe '#id' do
-
-      let(:search_result) do
-        Article.search('title:test')
-      end
-
-      it 'returns the type' do
-        expect(search_result.results.first.type).to eq('article')
-      end
-    end
-
     describe '#each_with_hit' do
 
       let(:search_result) do

--- a/opensearch-model/spec/opensearch/model/adapters/active_record/basic_spec.rb
+++ b/opensearch-model/spec/opensearch/model/adapters/active_record/basic_spec.rb
@@ -67,7 +67,7 @@ describe OpenSearch::Model::Adapter::ActiveRecord do
       end
 
       Article.delete_all
-      Article.__opensearch__.create_index!(force: true, include_type_name: true)
+      Article.__opensearch__.create_index!(force: true)
 
       Article.create!(title: 'Test', body: '', clicks: 1)
       Article.create!(title: 'Testing Coding', body: '', clicks: 2)

--- a/opensearch-model/spec/opensearch/model/adapters/active_record/namespaced_model_spec.rb
+++ b/opensearch-model/spec/opensearch/model/adapters/active_record/namespaced_model_spec.rb
@@ -27,7 +27,7 @@ describe 'OpenSearch::Model::Adapter::ActiveRecord Namespaced Model' do
     end
 
     MyNamespace::Book.delete_all
-    MyNamespace::Book.__opensearch__.create_index!(force: true, include_type_name: true)
+    MyNamespace::Book.__opensearch__.create_index!(force: true)
     MyNamespace::Book.create!(title: 'Test')
     MyNamespace::Book.__opensearch__.refresh_index!
   end

--- a/opensearch-model/spec/opensearch/model/adapters/active_record/parent_child_spec.rb
+++ b/opensearch-model/spec/opensearch/model/adapters/active_record/parent_child_spec.rb
@@ -38,7 +38,7 @@ describe 'OpenSearch::Model::Adapter::ActiveRecord Parent-Child' do
       add_index(:answers, :question_id) unless index_exists?(:answers, :question_id)
 
       clear_tables(Question)
-      ParentChildSearchable.create_index!(force: true, include_type_name: true)
+      ParentChildSearchable.create_index!(force: true)
 
       q_1 = Question.create!(title: 'First Question',  author: 'John')
       q_2 = Question.create!(title: 'Second Question', author: 'Jody')

--- a/opensearch-model/spec/opensearch/model/adapters/active_record/serialization_spec.rb
+++ b/opensearch-model/spec/opensearch/model/adapters/active_record/serialization_spec.rb
@@ -41,9 +41,7 @@ describe 'OpenSearch::Model::Adapter::ActiveRecord Serialization' do
     context 'when a document is indexed' do
 
       let(:search_result) do
-        ArticleWithCustomSerialization.__opensearch__.client.get(index: 'article_with_custom_serializations',
-                                                                    type:  '_doc',
-                                                                    id:    '1')
+        ArticleWithCustomSerialization.__opensearch__.client.get(index: 'article_with_custom_serializations', id: '1')
       end
 
       it 'applies the serialization when indexing' do
@@ -66,7 +64,6 @@ describe 'OpenSearch::Model::Adapter::ActiveRecord Serialization' do
 
       let(:search_result) do
         ArticleWithCustomSerialization.__opensearch__.client.get(index: 'article_with_custom_serializations',
-                                                                    type:  '_doc',
                                                                     id:    article.id)
       end
 

--- a/opensearch-model/spec/opensearch/model/importing_spec.rb
+++ b/opensearch-model/spec/opensearch/model/importing_spec.rb
@@ -60,7 +60,6 @@ describe OpenSearch::Model::Importing do
 
     before do
       allow(DummyImportingModel).to receive(:index_name).and_return('foo')
-      allow(DummyImportingModel).to receive(:document_type).and_return('foo')
       allow(DummyImportingModel).to receive(:index_exists?).and_return(true)
       allow(DummyImportingModel).to receive(:__batch_to_bulk)
       allow(client).to receive(:bulk).and_return(response)
@@ -159,23 +158,11 @@ describe OpenSearch::Model::Importing do
 
       before do
         expect(DummyImportingModel).to receive(:client).and_return(client)
-        expect(client).to receive(:bulk).with(body: nil, index: 'my-new-index', type: 'foo').and_return(response)
+        expect(client).to receive(:bulk).with(body: nil, index: 'my-new-index').and_return(response)
       end
 
       it 'uses the alternate index name' do
         expect(DummyImportingModel.import(index: 'my-new-index')).to eq(0)
-      end
-    end
-
-    context 'when a different document type is provided' do
-
-      before do
-        expect(DummyImportingModel).to receive(:client).and_return(client)
-        expect(client).to receive(:bulk).with(body: nil, index: 'foo', type: 'my-new-type').and_return(response)
-      end
-
-      it 'uses the alternate index name' do
-        expect(DummyImportingModel.import(type: 'my-new-type')).to eq(0)
       end
     end
 
@@ -232,7 +219,7 @@ describe OpenSearch::Model::Importing do
 
       before do
         expect(DummyImportingModel).to receive(:client).and_return(client)
-        expect(client).to receive(:bulk).with(body: nil, index: 'foo', type: 'foo', pipeline: 'my-pipeline').and_return(response)
+        expect(client).to receive(:bulk).with(body: nil, index: 'foo', pipeline: 'my-pipeline').and_return(response)
       end
 
       it 'uses the pipeline option' do

--- a/opensearch-model/spec/opensearch/model/indexing_spec.rb
+++ b/opensearch-model/spec/opensearch/model/indexing_spec.rb
@@ -131,25 +131,6 @@ describe OpenSearch::Model::Indexing do
       it 'uses text as the default field type' do
         expect(mappings.to_hash[:mytype][:properties][:bar][:type]).to eq('text')
       end
-
-      context 'when the \'include_type_name\' option is specified' do
-
-        let(:mappings) do
-          OpenSearch::Model::Indexing::Mappings.new(:mytype, include_type_name: true)
-        end
-
-        before do
-          mappings.indexes :foo, { type: 'boolean', include_in_all: false }
-        end
-
-        it 'creates the correct mapping definition' do
-          expect(mappings.to_hash[:mytype][:properties][:foo][:type]).to eq('boolean')
-        end
-
-        it 'sets the \'include_type_name\' option' do
-          expect(mappings.to_hash[:mytype][:include_type_name]).to eq(true)
-        end
-      end
     end
 
     context 'when a type is not specified' do
@@ -173,9 +154,8 @@ describe OpenSearch::Model::Indexing do
     end
 
     context 'when specific mappings are defined' do
-
       let(:mappings) do
-        OpenSearch::Model::Indexing::Mappings.new(:mytype, include_type_name: true)
+        OpenSearch::Model::Indexing::Mappings.new(:mytype)
       end
 
       before do
@@ -242,10 +222,6 @@ describe OpenSearch::Model::Indexing do
           expect(mappings.to_hash[:mytype][:properties][:foo_nested_as_symbol][:type]).to eq(:nested)
           expect(mappings.to_hash[:mytype][:properties][:foo_nested_as_symbol][:properties]).not_to be_nil
           expect(mappings.to_hash[:mytype][:properties][:foo_nested_as_symbol][:fields]).to be_nil
-        end
-
-        it 'defines the settings' do
-          expect(mappings.to_hash[:mytype][:include_type_name]).to be(true)
         end
       end
     end

--- a/opensearch-model/spec/opensearch/model/indexing_spec.rb
+++ b/opensearch-model/spec/opensearch/model/indexing_spec.rb
@@ -94,7 +94,7 @@ describe OpenSearch::Model::Indexing do
   describe '#mappings' do
 
     let(:expected_mapping_hash) do
-      { :mytype => { foo: 'bar', :properties => {} } }
+      { foo: 'bar', :properties => {} }
     end
 
     it 'returns an instance of the Mappings class' do
@@ -106,17 +106,17 @@ describe OpenSearch::Model::Indexing do
     end
 
     it 'should be convertible to a hash' do
-      expect(OpenSearch::Model::Indexing::Mappings.new(:mytype, { foo: 'bar' }).to_hash).to eq(expected_mapping_hash)
+      expect(OpenSearch::Model::Indexing::Mappings.new({ foo: 'bar' }).to_hash).to eq(expected_mapping_hash)
     end
 
     it 'should be convertible to json' do
-      expect(OpenSearch::Model::Indexing::Mappings.new(:mytype, { foo: 'bar' }).as_json).to eq(expected_mapping_hash)
+      expect(OpenSearch::Model::Indexing::Mappings.new({ foo: 'bar' }).as_json).to eq(expected_mapping_hash)
     end
 
     context 'when a type is specified' do
 
       let(:mappings) do
-        OpenSearch::Model::Indexing::Mappings.new(:mytype)
+        OpenSearch::Model::Indexing::Mappings.new
       end
 
       before do
@@ -125,11 +125,11 @@ describe OpenSearch::Model::Indexing do
       end
 
       it 'creates the correct mapping definition' do
-        expect(mappings.to_hash[:mytype][:properties][:foo][:type]).to eq('boolean')
+        expect(mappings.to_hash[:properties][:foo][:type]).to eq('boolean')
       end
 
       it 'uses text as the default field type' do
-        expect(mappings.to_hash[:mytype][:properties][:bar][:type]).to eq('text')
+        expect(mappings.to_hash[:properties][:bar][:type]).to eq('text')
       end
     end
 
@@ -155,7 +155,7 @@ describe OpenSearch::Model::Indexing do
 
     context 'when specific mappings are defined' do
       let(:mappings) do
-        OpenSearch::Model::Indexing::Mappings.new(:mytype)
+        OpenSearch::Model::Indexing::Mappings.new
       end
 
       before do
@@ -164,11 +164,11 @@ describe OpenSearch::Model::Indexing do
       end
 
       it 'creates the correct mapping definition' do
-        expect(mappings.to_hash[:mytype][:properties][:foo][:type]).to eq('boolean')
+        expect(mappings.to_hash[:properties][:foo][:type]).to eq('boolean')
       end
 
       it 'uses text as the default type' do
-        expect(mappings.to_hash[:mytype][:properties][:bar][:type]).to eq('text')
+        expect(mappings.to_hash[:properties][:bar][:type]).to eq('text')
       end
 
       context 'when mappings are defined for multiple fields' do
@@ -180,9 +180,9 @@ describe OpenSearch::Model::Indexing do
         end
 
         it 'defines the mapping for all the fields' do
-          expect(mappings.to_hash[:mytype][:properties][:my_field][:type]).to eq('text')
-          expect(mappings.to_hash[:mytype][:properties][:my_field][:fields][:raw][:type]).to eq('keyword')
-          expect(mappings.to_hash[:mytype][:properties][:my_field][:fields][:raw][:properties]).to be_nil
+          expect(mappings.to_hash[:properties][:my_field][:type]).to eq('text')
+          expect(mappings.to_hash[:properties][:my_field][:fields][:raw][:type]).to eq('keyword')
+          expect(mappings.to_hash[:properties][:my_field][:fields][:raw][:properties]).to be_nil
         end
       end
 
@@ -207,21 +207,21 @@ describe OpenSearch::Model::Indexing do
         end
 
         it 'defines mappings for the embedded properties' do
-          expect(mappings.to_hash[:mytype][:properties][:foo][:type]).to eq('object')
-          expect(mappings.to_hash[:mytype][:properties][:foo][:properties][:bar][:type]).to eq('text')
-          expect(mappings.to_hash[:mytype][:properties][:foo][:fields]).to be_nil
+          expect(mappings.to_hash[:properties][:foo][:type]).to eq('object')
+          expect(mappings.to_hash[:properties][:foo][:properties][:bar][:type]).to eq('text')
+          expect(mappings.to_hash[:properties][:foo][:fields]).to be_nil
 
-          expect(mappings.to_hash[:mytype][:properties][:foo_object][:type]).to eq('object')
-          expect(mappings.to_hash[:mytype][:properties][:foo_object][:properties][:bar][:type]).to eq('text')
-          expect(mappings.to_hash[:mytype][:properties][:foo_object][:fields]).to be_nil
+          expect(mappings.to_hash[:properties][:foo_object][:type]).to eq('object')
+          expect(mappings.to_hash[:properties][:foo_object][:properties][:bar][:type]).to eq('text')
+          expect(mappings.to_hash[:properties][:foo_object][:fields]).to be_nil
 
-          expect(mappings.to_hash[:mytype][:properties][:foo_nested][:type]).to eq('nested')
-          expect(mappings.to_hash[:mytype][:properties][:foo_nested][:properties][:bar][:type]).to eq('text')
-          expect(mappings.to_hash[:mytype][:properties][:foo_nested][:fields]).to be_nil
+          expect(mappings.to_hash[:properties][:foo_nested][:type]).to eq('nested')
+          expect(mappings.to_hash[:properties][:foo_nested][:properties][:bar][:type]).to eq('text')
+          expect(mappings.to_hash[:properties][:foo_nested][:fields]).to be_nil
 
-          expect(mappings.to_hash[:mytype][:properties][:foo_nested_as_symbol][:type]).to eq(:nested)
-          expect(mappings.to_hash[:mytype][:properties][:foo_nested_as_symbol][:properties]).not_to be_nil
-          expect(mappings.to_hash[:mytype][:properties][:foo_nested_as_symbol][:fields]).to be_nil
+          expect(mappings.to_hash[:properties][:foo_nested_as_symbol][:type]).to eq(:nested)
+          expect(mappings.to_hash[:properties][:foo_nested_as_symbol][:properties]).not_to be_nil
+          expect(mappings.to_hash[:properties][:foo_nested_as_symbol][:fields]).to be_nil
         end
       end
     end
@@ -258,13 +258,12 @@ describe OpenSearch::Model::Indexing do
 
         before do
           DummyIndexingModel.instance_variable_set(:@mapping, nil)
-          DummyIndexingModel.document_type(:mytype)
           DummyIndexingModel.mappings(foo: 'boo')
           DummyIndexingModel.mappings(bar: 'bam')
         end
 
         let(:expected_mappings_hash) do
-          { mytype: { foo: "boo", bar: "bam", properties: {} } }
+          { foo: "boo", bar: "bam", properties: {} }
         end
 
         it 'sets the mappings' do
@@ -394,7 +393,6 @@ describe OpenSearch::Model::Indexing do
         expect(instance).to receive(:client).and_return(client)
         expect(instance).to receive(:as_indexed_json).and_return('JSON')
         expect(instance).to receive(:index_name).and_return('foo')
-        expect(instance).to receive(:document_type).twice.and_return('bar')
         expect(instance).to receive(:id).and_return('1')
       end
 
@@ -409,7 +407,7 @@ describe OpenSearch::Model::Indexing do
       context 'when no options are passed to the method' do
 
         before do
-          expect(client).to receive(:index).with(index: 'foo', type: 'bar', id: '1', body: 'JSON').and_return(true)
+          expect(client).to receive(:index).with(index: 'foo', id: '1', body: 'JSON').and_return(true)
         end
 
         it 'provides the method on an instance' do
@@ -420,7 +418,7 @@ describe OpenSearch::Model::Indexing do
       context 'when extra options are passed to the method' do
 
         before do
-          expect(client).to receive(:index).with(index: 'foo', type: 'bar', id: '1', body: 'JSON', parent: 'A').and_return(true)
+          expect(client).to receive(:index).with(index: 'foo', id: '1', body: 'JSON', parent: 'A').and_return(true)
         end
 
         it 'passes the extra options to the method call on the client' do
@@ -434,7 +432,6 @@ describe OpenSearch::Model::Indexing do
       before do
         expect(instance).to receive(:client).and_return(client)
         expect(instance).to receive(:index_name).and_return('foo')
-        expect(instance).to receive(:document_type).twice.and_return('bar')
         expect(instance).to receive(:id).and_return('1')
       end
 
@@ -449,7 +446,7 @@ describe OpenSearch::Model::Indexing do
       context 'when no options are passed to the method' do
 
         before do
-          expect(client).to receive(:delete).with(index: 'foo', type: 'bar', id: '1').and_return(true)
+          expect(client).to receive(:delete).with(index: 'foo', id: '1').and_return(true)
         end
 
         it 'provides the method on an instance' do
@@ -460,7 +457,7 @@ describe OpenSearch::Model::Indexing do
       context 'when extra options are passed to the method' do
 
         before do
-          expect(client).to receive(:delete).with(index: 'foo', type: 'bar', id: '1', parent: 'A').and_return(true)
+          expect(client).to receive(:delete).with(index: 'foo', id: '1', parent: 'A').and_return(true)
         end
 
         it 'passes the extra options to the method call on the client' do
@@ -505,7 +502,7 @@ describe OpenSearch::Model::Indexing do
 
           before do
             instance.instance_variable_set(:@__changed_model_attributes, { foo: 'bar' })
-            expect(client).to receive(:update).with(index: 'foo', type: 'bar', id: '1', body: { doc: { foo: 'bar' } }).and_return(true)
+            expect(client).to receive(:update).with(index: 'foo', id: '1', body: { doc: { foo: 'bar' } }).and_return(true)
           end
 
           it 'updates the document' do
@@ -521,7 +518,7 @@ describe OpenSearch::Model::Indexing do
 
           before do
             instance.instance_variable_set(:@__changed_model_attributes, {'foo' => 'B', 'bar' => 'D' })
-            expect(client).to receive(:update).with(index: 'foo', type: 'bar', id: '1', body: { doc: { foo: 'B' } }).and_return(true)
+            expect(client).to receive(:update).with(index: 'foo', id: '1', body: { doc: { foo: 'B' } }).and_return(true)
           end
 
           it 'updates the document' do
@@ -553,7 +550,7 @@ describe OpenSearch::Model::Indexing do
           before do
             instance.instance_variable_set(:@__changed_model_attributes, { 'foo' => { 'bar' => 'BAR'} })
             expect(instance).to receive(:as_indexed_json).and_return('foo' => 'BAR')
-            expect(client).to receive(:update).with(index: 'foo', type: 'bar', id: '1', body: { doc: { 'foo' => 'BAR' } }).and_return(true)
+            expect(client).to receive(:update).with(index: 'foo', id: '1', body: { doc: { 'foo' => 'BAR' } }).and_return(true)
           end
 
           it 'updates the document' do
@@ -578,7 +575,6 @@ describe OpenSearch::Model::Indexing do
         before do
           expect(instance).to receive(:client).and_return(client)
           expect(instance).to receive(:index_name).and_return('foo')
-          expect(instance).to receive(:document_type).twice.and_return('bar')
           expect(instance).to receive(:id).and_return('1')
           instance.instance_variable_set(:@__changed_model_attributes, { author: 'john' })
         end
@@ -586,7 +582,7 @@ describe OpenSearch::Model::Indexing do
         context 'when no options are specified' do
 
           before do
-            expect(client).to receive(:update).with(index: 'foo', type: 'bar', id: '1', body: { doc: { title: 'green' } }).and_return(true)
+            expect(client).to receive(:update).with(index: 'foo', id: '1', body: { doc: { title: 'green' } }).and_return(true)
           end
 
           it 'updates the document' do
@@ -597,7 +593,7 @@ describe OpenSearch::Model::Indexing do
         context 'when extra options are provided' do
 
           before do
-            expect(client).to receive(:update).with(index: 'foo', type: 'bar', id: '1', body: { doc: { title: 'green' } }, refresh: true).and_return(true)
+            expect(client).to receive(:update).with(index: 'foo', id: '1', body: { doc: { title: 'green' } }, refresh: true).and_return(true)
           end
 
           it 'updates the document' do

--- a/opensearch-model/spec/opensearch/model/indexing_spec.rb
+++ b/opensearch-model/spec/opensearch/model/indexing_spec.rb
@@ -113,26 +113,6 @@ describe OpenSearch::Model::Indexing do
       expect(OpenSearch::Model::Indexing::Mappings.new({ foo: 'bar' }).as_json).to eq(expected_mapping_hash)
     end
 
-    context 'when a type is specified' do
-
-      let(:mappings) do
-        OpenSearch::Model::Indexing::Mappings.new
-      end
-
-      before do
-        mappings.indexes :foo, { type: 'boolean', include_in_all: false }
-        mappings.indexes :bar
-      end
-
-      it 'creates the correct mapping definition' do
-        expect(mappings.to_hash[:properties][:foo][:type]).to eq('boolean')
-      end
-
-      it 'uses text as the default field type' do
-        expect(mappings.to_hash[:properties][:bar][:type]).to eq('text')
-      end
-    end
-
     context 'when a type is not specified' do
 
       let(:mappings) do

--- a/opensearch-model/spec/opensearch/model/response/pagination/kaminari_spec.rb
+++ b/opensearch-model/spec/opensearch/model/response/pagination/kaminari_spec.rb
@@ -58,7 +58,7 @@ describe 'OpenSearch::Model::Response::Response Kaminari' do
       context 'when page is called once' do
 
         let(:search_request) do
-          { index: index_field, from: 25, size: 25, q: '*', type: type_field}
+          { index: index_field, from: 25, size: 25, q: '*'}
         end
 
         before do
@@ -75,11 +75,11 @@ describe 'OpenSearch::Model::Response::Response Kaminari' do
       context 'when page is called more than once' do
 
         let(:search_request_one) do
-          { index: index_field, from: 25, size: 25, q: '*', type: type_field}
+          { index: index_field, from: 25, size: 25, q: '*'}
         end
 
         let(:search_request_two) do
-          { index: index_field, from: 75, size: 25, q: '*', type: type_field}
+          { index: index_field, from: 75, size: 25, q: '*'}
         end
 
         before do
@@ -399,10 +399,6 @@ describe 'OpenSearch::Model::Response::Response Kaminari' do
         ModelClass
       end
 
-      let(:type_field) do
-        'bar'
-      end
-
       let(:index_field) do
         'foo'
       end
@@ -414,10 +410,6 @@ describe 'OpenSearch::Model::Response::Response Kaminari' do
 
       let(:model) do
         OpenSearch::Model::Multimodel.new(ModelClass)
-      end
-
-      let(:type_field) do
-        ['bar']
       end
 
       let(:index_field) do
@@ -441,10 +433,6 @@ describe 'OpenSearch::Model::Response::Response Kaminari' do
         ModelClass
       end
 
-      let(:type_field) do
-        'bar'
-      end
-
       let(:index_field) do
         'foo'
       end
@@ -456,10 +444,6 @@ describe 'OpenSearch::Model::Response::Response Kaminari' do
 
       let(:model) do
         OpenSearch::Model::Multimodel.new(ModelClass)
-      end
-
-      let(:type_field) do
-        ['bar']
       end
 
       let(:index_field) do

--- a/opensearch-model/spec/opensearch/model/searching_search_request_spec.rb
+++ b/opensearch-model/spec/opensearch/model/searching_search_request_spec.rb
@@ -44,7 +44,7 @@ describe OpenSearch::Model::Serializing do
     context 'when the search definition is a simple query' do
 
       before do
-        expect(client).to receive(:search).with(index: 'foo', type: 'bar', q: 'foo').and_return({})
+        expect(client).to receive(:search).with(index: 'foo', q: 'foo').and_return({})
       end
 
       let(:search) do
@@ -59,7 +59,7 @@ describe OpenSearch::Model::Serializing do
     context 'when the search definition is a hash' do
 
       before do
-        expect(client).to receive(:search).with(index: 'foo', type: 'bar', body: { foo: 'bar' }).and_return({})
+        expect(client).to receive(:search).with(index: 'foo', body: { foo: 'bar' }).and_return({})
       end
 
       let(:search) do
@@ -74,7 +74,7 @@ describe OpenSearch::Model::Serializing do
     context 'when the search definition is a json string' do
 
       before do
-        expect(client).to receive(:search).with(index: 'foo', type: 'bar', body: '{"foo":"bar"}').and_return({})
+        expect(client).to receive(:search).with(index: 'foo', body: '{"foo":"bar"}').and_return({})
       end
 
       let(:search) do
@@ -99,7 +99,7 @@ describe OpenSearch::Model::Serializing do
       end
 
       before do
-        expect(client).to receive(:search).with(index: 'foo', type: 'bar', body: {foo: 'bar'}).and_return({})
+        expect(client).to receive(:search).with(index: 'foo', body: {foo: 'bar'}).and_return({})
       end
 
       let(:search) do
@@ -114,7 +114,7 @@ describe OpenSearch::Model::Serializing do
     context 'when extra options are specified' do
 
       before do
-        expect(client).to receive(:search).with(index: 'foo', type: 'bar', q: 'foo', size: 15).and_return({})
+        expect(client).to receive(:search).with(index: 'foo', q: 'foo', size: 15).and_return({})
       end
 
       let(:search) do

--- a/opensearch-model/spec/support/app/parent_and_child_searchable.rb
+++ b/opensearch-model/spec/support/app/parent_and_child_searchable.rb
@@ -27,9 +27,9 @@ module ParentChildSearchable
     mapping_properties = { join_field: { type: JOIN,
                                          relations: { Question::JOIN_TYPE => Answer::JOIN_TYPE } } }
 
-    merged_properties = mapping_properties.merge(Question.mappings.to_hash[:doc][:properties]).merge(
-        Answer.mappings.to_hash[:doc][:properties])
-    mappings = { doc: { properties: merged_properties }}
+    merged_properties = mapping_properties.merge(Question.mappings.to_hash[:properties]).merge(
+        Answer.mappings.to_hash[:properties])
+    mappings = { properties: merged_properties }
 
     client.indices.create({ index: INDEX_NAME,
                             body: {

--- a/opensearch-persistence/README.md
+++ b/opensearch-persistence/README.md
@@ -10,7 +10,7 @@ The library version numbers follow the OpenSearch major versions. The `main` bra
 
 | Rubygem       |   | OpenSearch    |
 |:-------------:|:-:| :-----------: |
-| main          | → | 1.x           |
+| main          | → | 2.x           |
 
 ## Installation
 

--- a/opensearch-persistence/README.md
+++ b/opensearch-persistence/README.md
@@ -140,7 +140,7 @@ class MyRepository
 end
 
 client = OpenSearch::Client.new(url: ENV['OPENSEARCH_URL'], log: true)
-repository = MyRepository.new(client: client, index_name: :my_notes, type: :note, klass: Note)
+repository = MyRepository.new(client: client, index_name: :my_notes, klass: Note)
 repository.settings number_of_shards: 1 do
   mapping do
     indexes :text, analyzer: 'snowball'

--- a/opensearch-persistence/examples/notes/Gemfile
+++ b/opensearch-persistence/examples/notes/Gemfile
@@ -25,7 +25,7 @@ gem 'oj'
 gem 'hashie'
 
 gem 'patron'
-gem 'opensearch-ruby', '~> 1.0'
+gem 'opensearch-ruby', '~> 2.0'
 gem 'opensearch-model',       git: 'https://github.com/compliance-innovations/opensearch-rails.git'
 gem 'opensearch-persistence', git: 'https://github.com/compliance-innovations/opensearch-rails.git'
 

--- a/opensearch-persistence/lib/opensearch/persistence/repository/find.rb
+++ b/opensearch-persistence/lib/opensearch/persistence/repository/find.rb
@@ -64,7 +64,6 @@ module OpenSearch
         #
         def exists?(id, options={})
           request = { index: index_name, id: id }
-          request[:type] = document_type if document_type
           client.exists(request.merge(options))
         end
 
@@ -84,7 +83,6 @@ module OpenSearch
         #
         def __find_one(id, options={})
           request = { index: index_name, id: id }
-          request[:type] = document_type if document_type
           document = client.get(request.merge(options))
           deserialize(document)
         rescue OpenSearch::Transport::Transport::Errors::NotFound => e
@@ -95,7 +93,6 @@ module OpenSearch
         #
         def __find_many(ids, options={})
           request = { index: index_name, body: { ids: ids } }
-          request[:type] = document_type if document_type
           documents = client.mget(request.merge(options))
           documents[DOCS].map do |document|
             deserialize(document) if document[FOUND]

--- a/opensearch-persistence/lib/opensearch/persistence/repository/search.rb
+++ b/opensearch-persistence/lib/opensearch/persistence/repository/search.rb
@@ -60,8 +60,7 @@ module OpenSearch
         # @return [OpenSearch::Persistence::Repository::Response::Results]
         #
         def search(query_or_definition, options={})
-          request = { index: index_name,
-                      type: document_type }
+          request = { index: index_name }
           if query_or_definition.respond_to?(:to_hash)
             request[:body] = query_or_definition.to_hash
           elsif query_or_definition.is_a?(String)
@@ -98,8 +97,7 @@ module OpenSearch
         #
         def count(query_or_definition=nil, options={})
           query_or_definition ||= { query: { match_all: {} } }
-          request = { index: index_name,
-                      type: document_type }
+          request = { index: index_name }
 
           if query_or_definition.respond_to?(:to_hash)
             request[:body] = query_or_definition.to_hash

--- a/opensearch-persistence/lib/opensearch/persistence/repository/store.rb
+++ b/opensearch-persistence/lib/opensearch/persistence/repository/store.rb
@@ -40,7 +40,6 @@ module OpenSearch
           request = { index: index_name,
                       id: id,
                       body: serialized }
-          request[:type] = document_type if document_type
           client.index(request.merge(options))
         end
 
@@ -65,7 +64,6 @@ module OpenSearch
           if document_or_id.is_a?(String) || document_or_id.is_a?(Integer)
             id = document_or_id
             body = options
-            type = document_type
           else
             document = serialize(document_or_id)
             id = __extract_id_from_document(document)
@@ -74,9 +72,8 @@ module OpenSearch
             else
               body = { doc: document }.merge(options)
             end
-            type = document.delete(:type) || document_type
           end
-          client.update(index: index_name, id: id, type: type, body: body)
+          client.update(index: index_name, id: id, body: body)
         end
 
         # Remove the serialized object or document with specified ID from OpenSearch
@@ -98,7 +95,7 @@ module OpenSearch
             serialized = serialize(document_or_id)
             id = __get_id_from_document(serialized)
           end
-          client.delete({ index: index_name, type: document_type, id: id }.merge(options))
+          client.delete({ index: index_name, id: id }.merge(options))
         end
       end
     end

--- a/opensearch-persistence/lib/opensearch/persistence/version.rb
+++ b/opensearch-persistence/lib/opensearch/persistence/version.rb
@@ -17,6 +17,6 @@
 
 module OpenSearch
   module Persistence
-    VERSION = '0.1.1'
+    VERSION = '1.0.0'
   end
 end

--- a/opensearch-persistence/opensearch-persistence.gemspec
+++ b/opensearch-persistence/opensearch-persistence.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.3"
 
-  s.add_dependency "opensearch-ruby", '~> 1.0'
+  s.add_dependency "opensearch-ruby", '~> 2.0'
   s.add_dependency "opensearch-model"
   s.add_dependency "activesupport",       '> 4'
   s.add_dependency "activemodel",         '> 4'

--- a/opensearch-persistence/spec/repository/find_spec.rb
+++ b/opensearch-persistence/spec/repository/find_spec.rb
@@ -46,17 +46,6 @@ describe OpenSearch::Persistence::Repository::Find do
         expect(repository.exists?('1')).to be(false)
       end
     end
-
-    context 'when options are provided' do
-
-      let(:id) do
-        repository.save(a: 1)['_id']
-      end
-
-      it 'applies the options' do
-        expect(repository.exists?(id, type: 'other_type')).to be(false)
-      end
-    end
   end
 
   describe '#find' do
@@ -128,48 +117,6 @@ describe OpenSearch::Persistence::Repository::Find do
           expect {
             repository.find(1)
           }.to raise_exception(OpenSearch::Persistence::Repository::DocumentNotFound)
-        end
-      end
-    end
-
-    context 'when options are provided' do
-
-      context 'when a single id is passed' do
-
-        let!(:id) do
-          repository.save(a: 1)['_id']
-        end
-
-        it 'applies the options' do
-          expect {
-            repository.find(id, type: 'none')
-          }.to raise_exception(OpenSearch::Persistence::Repository::DocumentNotFound)
-        end
-      end
-
-      context 'when an array of ids is passed' do
-
-        let!(:ids) do
-          3.times.collect do |i|
-            repository.save(a: i)['_id']
-          end
-        end
-
-        it 'applies the options' do
-          expect(repository.find(ids, type: 'none')).to eq([nil, nil, nil])
-        end
-      end
-
-      context 'when multiple ids are passed' do
-
-        let!(:ids) do
-          3.times.collect do |i|
-            repository.save(a: i)['_id']
-          end
-        end
-
-        it 'applies the options' do
-          expect(repository.find(*ids, type: 'none')).to eq([nil, nil, nil])
         end
       end
     end

--- a/opensearch-persistence/spec/repository/search_spec.rb
+++ b/opensearch-persistence/spec/repository/search_spec.rb
@@ -29,169 +29,55 @@ describe OpenSearch::Persistence::Repository::Search do
       DEFAULT_REPOSITORY
     end
 
-    context 'when the repository does not have a type set' do
-
       before do
         repository.save({ name: 'user' }, refresh: true)
       end
 
-      context 'when a query definition is provided as a hash' do
+    context 'when a query definition is provided as a hash' do
 
-        it 'uses the default document type' do
-          expect(repository.search({ query: { match: { name: 'user' } } }).first).to eq('name' => 'user')
-        end
-      end
-
-      context 'when a query definition is provided as a string' do
-
-        it 'uses the default document type' do
-          expect(repository.search('user').first).to eq('name' => 'user')
-        end
-      end
-
-      context 'when the query definition is neither a String nor a Hash' do
-
-        it 'raises an ArgumentError' do
-          expect {
-            repository.search(1)
-          }.to raise_exception(ArgumentError)
-        end
-      end
-
-      context 'when options are provided' do
-
-        context 'when a query definition is provided as a hash' do
-
-          it 'uses the default document type' do
-            expect(repository.search({ query: { match: { name: 'user' } } }, type: 'other').first).to be_nil
-          end
-        end
-
-        context 'when a query definition is provided as a string' do
-
-          it 'uses the default document type' do
-            expect(repository.search('user', type: 'other').first).to be_nil
-          end
-        end
-
-        context 'when the query definition is neither a String nor a Hash' do
-
-          it 'raises an ArgumentError' do
-            expect {
-              repository.search(1)
-            }.to raise_exception(ArgumentError)
-          end
-        end
+      it 'uses the default document type' do
+        expect(repository.search({ query: { match: { name: 'user' } } }).first).to eq('name' => 'user')
       end
     end
 
-    context 'when the repository does have a type set' do
+    context 'when a query definition is provided as a string' do
 
-      let(:repository) do
-        MyTestRepository.new(document_type: 'other_note')
+      it 'uses the default document type' do
+        expect(repository.search('user').first).to eq('name' => 'user')
       end
+    end
 
-      before do
-        repository.save({ name: 'user' }, refresh: true)
-      end
+    context 'when the query definition is neither a String nor a Hash' do
 
-      context 'when options are provided' do
-
-        context 'when a query definition is provided as a hash' do
-
-          it 'uses the options' do
-            expect(repository.search({ query: { match: { name: 'user' } } }, type: 'other').first).to be_nil
-          end
-        end
-
-        context 'when a query definition is provided as a string' do
-
-          it 'uses the options' do
-            expect(repository.search('user', type: 'other').first).to be_nil
-          end
-        end
-
-        context 'when the query definition is neither a String nor a Hash' do
-
-          it 'raises an ArgumentError' do
-            expect {
-              repository.search(1)
-            }.to raise_exception(ArgumentError)
-          end
-        end
+      it 'raises an ArgumentError' do
+        expect {
+          repository.search(1)
+        }.to raise_exception(ArgumentError)
       end
     end
   end
 
   describe '#count' do
 
-    context 'when the repository does not have a type set' do
+    let(:repository) do
+      DEFAULT_REPOSITORY
+    end
 
-      let(:repository) do
-        DEFAULT_REPOSITORY
-      end
+    before do
+      repository.save({ name: 'user' }, refresh: true)
+    end
 
-      before do
-        repository.save({ name: 'user' }, refresh: true)
-      end
+    context 'when a query definition is provided as a hash' do
 
-      context 'when a query definition is provided as a hash' do
-
-        it 'uses the default document type' do
-          expect(repository.count({ query: { match: { name: 'user' } } })).to eq(1)
-        end
-      end
-
-      context 'when a query definition is provided as a string' do
-
-        it 'uses the default document type' do
-          expect(repository.count('user')).to eq(1)
-        end
-      end
-
-      context 'when options are provided' do
-
-        context 'when a query definition is provided as a hash' do
-
-          it 'uses the options' do
-            expect(repository.count({ query: { match: { name: 'user' } } }, type: 'other')).to eq(0)
-          end
-        end
-
-        context 'when a query definition is provided as a string' do
-
-          it 'uses the options' do
-            expect(repository.count('user', type: 'other')).to eq(0)
-          end
-        end
+      it 'uses the default document type' do
+        expect(repository.count({ query: { match: { name: 'user' } } })).to eq(1)
       end
     end
 
-    context 'when the repository does have a type set' do
+    context 'when a query definition is provided as a string' do
 
-      let(:repository) do
-        MyTestRepository.new(document_type: 'other_note')
-      end
-
-      before do
-        repository.save({ name: 'user' }, refresh: true)
-      end
-
-      context 'when options are provided' do
-
-        context 'when a query definition is provided as a hash' do
-
-          it 'uses the options' do
-            expect(repository.count({ query: { match: { name: 'user' } } }, type: 'other')).to eq(0)
-          end
-        end
-
-        context 'when a query definition is provided as a string' do
-
-          it 'uses the options' do
-            expect(repository.count('user', type: 'other')).to eq(0)
-          end
-        end
+      it 'uses the default document type' do
+        expect(repository.count('user')).to eq(1)
       end
     end
   end

--- a/opensearch-persistence/spec/repository/store_spec.rb
+++ b/opensearch-persistence/spec/repository/store_spec.rb
@@ -74,14 +74,12 @@ describe OpenSearch::Persistence::Repository::Store do
     context 'when options are provided' do
 
       let!(:response) do
-        repository.save(document, type: 'other_note')
+        repository.save(document)
       end
 
       it 'saves the document using the options' do
-        expect {
-          repository.find(response['_id'])
-        }.to raise_exception(OpenSearch::Persistence::Repository::DocumentNotFound)
-        expect(repository.find(response['_id'], type: 'other_note')).to eq('a' => 1)
+        repository.find(response['_id'])
+        expect(repository.find(response['_id'])).to eq('a' => 1)
       end
     end
   end
@@ -331,7 +329,7 @@ describe OpenSearch::Persistence::Repository::Store do
     context 'when the document does not exist' do
 
       before do
-        repository.create_index!(include_type_name: true)
+        repository.create_index!
       end
 
       it 'raises an exception' do

--- a/opensearch-persistence/spec/repository_spec.rb
+++ b/opensearch-persistence/spec/repository_spec.rb
@@ -59,7 +59,7 @@ describe OpenSearch::Persistence::Repository do
       end
 
       it 'executes the block on the instance' do
-        expect(repository.mapping.to_hash).to eq(note: { dynamic: 'strict', properties: { foo: { type: 'text' } } })
+        expect(repository.mapping.to_hash).to eq( dynamic: 'strict', properties: { foo: { type: 'text' } })
       end
 
       context 'when options are provided in the args and set in the block' do
@@ -279,7 +279,7 @@ describe OpenSearch::Persistence::Repository do
 
         before do
           begin; repository.delete_index!; rescue; end
-          repository.create_index!(include_type_name: true)
+          repository.create_index!
         end
 
         it 'creates the index' do
@@ -334,7 +334,7 @@ describe OpenSearch::Persistence::Repository do
         end
 
         before do
-          repository.create_index!(include_type_name: true)
+          repository.create_index!
         end
 
         it 'refreshes the index' do
@@ -361,7 +361,7 @@ describe OpenSearch::Persistence::Repository do
         end
 
         before do
-          repository.create_index!(include_type_name: true)
+          repository.create_index!
         end
 
         it 'determines if the index exists' do
@@ -389,11 +389,10 @@ describe OpenSearch::Persistence::Repository do
     describe '#mapping' do
 
       let(:expected_mapping) do
-        { note: { dynamic: 'strict',
-                  properties: { foo: { type: 'object',
-                                       properties: { bar: { type: 'text' } } },
-                                baz: { type: 'text' } }
-                }
+        { dynamic: 'strict',
+          properties: { foo: { type: 'object',
+                               properties: { bar: { type: 'text' } } },
+                        baz: { type: 'text' } }
         }
       end
 
@@ -406,17 +405,16 @@ describe OpenSearch::Persistence::Repository do
       end
 
       it 'allows the value to be overridden with options on the instance' do
-        expect(RepositoryWithDSL.new(mapping: double('mapping', to_hash: { note: {} })).mapping.to_hash).to eq(note: {})
+        expect(RepositoryWithDSL.new(mapping: double('mapping', to_hash: {})).mapping.to_hash).to eq({})
       end
 
       context 'when the instance has a different document type' do
 
         let(:expected_mapping) do
-          { other_note: { dynamic: 'strict',
-                          properties: { foo: { type: 'object',
-                                               properties: { bar: { type: 'text' } } },
-                                        baz: { type: 'text' } }
-                        }
+          { dynamic: 'strict',
+            properties: { foo: { type: 'object',
+                                 properties: { bar: { type: 'text' } } },
+                          baz: { type: 'text' } }
           }
         end
 
@@ -547,24 +545,9 @@ describe OpenSearch::Persistence::Repository do
           RepositoryWithoutDSL.new(client: DEFAULT_CLIENT, document_type: 'mytype')
         end
 
-        context 'when the server is version >= 7.0', if: server_version > '7.0' do
-
-          context 'when the include_type_name option is specified' do
-
-            it 'creates an index' do
-              repository.create_index!(include_type_name: true)
-              expect(repository.index_exists?).to eq(true)
-            end
-          end
-
-          context 'when the include_type_name option is not specified' do
-
-            it 'raises an error' do
-              expect {
-                repository.create_index!
-              }.to raise_exception(OpenSearch::Transport::Transport::Errors::BadRequest)
-            end
-          end
+        it 'raises an error' do
+          repository.create_index!
+          expect(repository.index_exists?).to eq(true)
         end
       end
     end
@@ -582,7 +565,7 @@ describe OpenSearch::Persistence::Repository do
       end
 
       it 'deletes an index' do
-        repository.create_index!(include_type_name: true)
+        repository.create_index!
         repository.delete_index!
         expect(repository.index_exists?).to eq(false)
       end
@@ -605,7 +588,7 @@ describe OpenSearch::Persistence::Repository do
       end
 
       it 'refreshes an index' do
-        repository.create_index!(include_type_name: true)
+        repository.create_index!
         expect(repository.refresh_index!['_shards']).to be_a(Hash)
       end
     end
@@ -627,7 +610,7 @@ describe OpenSearch::Persistence::Repository do
       end
 
       it 'returns whether the index exists' do
-        repository.create_index!(include_type_name: true)
+        repository.create_index!
         expect(repository.index_exists?).to be(true)
       end
     end
@@ -645,17 +628,16 @@ describe OpenSearch::Persistence::Repository do
       end
 
       it 'allows the mapping to be set as an option' do
-        expect(RepositoryWithoutDSL.new(mapping: double('mapping', to_hash: { note: {} })).mapping.to_hash).to eq(note: {})
+        expect(RepositoryWithoutDSL.new(mapping: double('mapping', to_hash: { })).mapping.to_hash).to eq({})
       end
 
       context 'when a block is passed to the create method' do
 
         let(:expected_mapping) do
-          { note: { dynamic: 'strict',
-                    properties: { foo: { type: 'object',
-                                         properties: { bar: { type: 'text' } } },
-                                  baz: { type: 'text' } }
-            }
+          { dynamic: 'strict',
+            properties: { foo: { type: 'object',
+                                 properties: { bar: { type: 'text' } } },
+                          baz: { type: 'text' } }
           }
         end
 
@@ -677,7 +659,7 @@ describe OpenSearch::Persistence::Repository do
         context 'when the mapping is set in the options' do
 
           let(:repository) do
-            RepositoryWithoutDSL.create(mapping: double('mapping', to_hash: { note: {} })) do
+            RepositoryWithoutDSL.create(mapping: double('mapping', to_hash: { })) do
               mapping dynamic: 'strict' do
                 indexes :foo do
                   indexes :bar
@@ -688,7 +670,7 @@ describe OpenSearch::Persistence::Repository do
           end
 
           it 'uses the mapping from the options' do
-            expect(repository.mapping.to_hash).to eq(note: {})
+            expect(repository.mapping.to_hash).to eq({})
           end
         end
       end
@@ -725,11 +707,10 @@ describe OpenSearch::Persistence::Repository do
         context 'when a mapping is set in the block as well' do
 
           let(:expected_mapping) do
-            { note: { dynamic: 'strict',
-                      properties: { foo: { type: 'object',
-                                           properties: { bar: { type: 'text' } } },
-                                    baz: { type: 'text' } }
-                    }
+            { dynamic: 'strict',
+              properties: { foo: { type: 'object',
+                                   properties: { bar: { type: 'text' } } },
+                            baz: { type: 'text' } }
             }
           end
 

--- a/opensearch-rails/README.md
+++ b/opensearch-rails/README.md
@@ -74,7 +74,7 @@ require 'opensearch/rails/instrumentation'
 
 You should see an output like this in your application log in development environment:
 
-    Article Search (321.3ms) { index: "articles", type: "article", body: { query: ... } }
+    Article Search (321.3ms) { index: "articles", body: { query: ... } }
 
 Also, the total duration of the request to OpenSearch is displayed in the Rails request breakdown:
 

--- a/opensearch-rails/lib/opensearch/rails/version.rb
+++ b/opensearch-rails/lib/opensearch/rails/version.rb
@@ -17,6 +17,6 @@
 
 module OpenSearch
   module Rails
-    VERSION = "0.1.1"
+    VERSION = "1.0.0"
   end
 end

--- a/opensearch-rails/lib/rails/templates/01-basic.rb
+++ b/opensearch-rails/lib/rails/templates/01-basic.rb
@@ -156,7 +156,7 @@ puts
 say_status  "Rubygems", "Adding OpenSearch libraries into Gemfile...\n", :yellow
 puts        '-'*80, ''; sleep 0.75
 
-gem 'opensearch-ruby', '~> 1.0'
+gem 'opensearch-ruby', '~> 2.0'
 gem 'opensearch-model', git: 'https://github.com/compliance-innovations/opensearch-rails.git'
 gem 'opensearch-rails', git: 'https://github.com/compliance-innovations/opensearch-rails.git'
 

--- a/opensearch-rails/spec/instrumentation_spec.rb
+++ b/opensearch-rails/spec/instrumentation_spec.rb
@@ -67,8 +67,7 @@ describe 'ActiveSupport::Instrumentation integration' do
                                                                         { klass: 'DummyInstrumentationModel',
                                                                           name: 'Search',
                                                                           search: { body: query,
-                                                                          index: 'foo',
-                                                                          type: 'bar' } }).and_return({})
+                                                                          index: 'foo'} }).and_return({})
     end
 
     let(:query) do


### PR DESCRIPTION
As part of OpenSearch 2, support for mapping types is removed. As a result:
- the type parameter is removed from rest end-points.
- the include_type_name parameter is removed from API requests.

This pull request also removes these parameters from opensearch-rails.
See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html for more info on mapping types and why they are being removed.

See also:
- https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-2.0.0.md
- https://github.com/opensearch-project/cross-cluster-replication/issues/318
- https://github.com/opensearch-project/job-scheduler/pull/155
- https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html