### PR TITLE
Remove "type" argument from call to __opensearch__.import

### DIFF
--- a/opensearch-rails/lib/opensearch/rails/tasks/import.rb
+++ b/opensearch-rails/lib/opensearch/rails/tasks/import.rb
@@ -80,7 +80,6 @@ namespace :opensearch do
       total_errors = klass.__opensearch__.import force:      ENV.fetch('FORCE', false),
                                   batch_size: ENV.fetch('BATCH', 1000).to_i,
                                   index:      ENV.fetch('INDEX', nil),
-                                  type:       ENV.fetch('TYPE',  nil),
                                   scope:      ENV.fetch('SCOPE', nil) do |response|
         pbar.inc response['items'].size if pbar
         STDERR.flush


### PR DESCRIPTION
When running the `opensearch:import:all` task, I got this error:

```
rake aborted!
ArgumentError: unknown keyword: :type (ArgumentError)
/Users/aarestad/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/relation/batches.rb:148:in `find_in_batches'
/Users/aarestad/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/activerecord-7.1.3.2/lib/active_record/querying.rb:23:in `find_in_batches'
/Users/aarestad/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/bundler/gems/opensearch-rails-8b0af5b21128/opensearch-model/lib/opensearch/model/proxy.rb:124:in `method_missing'
/Users/aarestad/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/bundler/gems/opensearch-rails-8b0af5b21128/opensearch-model/lib/opensearch/model/adapters/active_record.rb:105:in `__find_in_batches'
/Users/aarestad/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/bundler/gems/opensearch-rails-8b0af5b21128/opensearch-model/lib/opensearch/model/importing.rb:160:in `import'
/Users/aarestad/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/bundler/gems/opensearch-rails-8b0af5b21128/opensearch-rails/lib/opensearch/rails/tasks/import.rb:80:in `block (3 levels) in <top (required)>'
<snip>
```

It seems that the "type" argument being used here is being rejected by Active Record in Rails 7.1. Is it safe to simply remove the argument?