### PR TITLE
Fixes a deprecation warning on the `#color` method

### DIFF
--- a/opensearch-rails/lib/opensearch/rails/instrumentation/log_subscriber.rb
+++ b/opensearch-rails/lib/opensearch/rails/instrumentation/log_subscriber.rb
@@ -47,7 +47,7 @@ module OpenSearch
           name    = "#{payload[:klass]} #{payload[:name]} (#{event.duration.round(1)}ms)"
           search  = payload[:search].inspect.gsub(/:(\w+)=>/, '\1: ')
 
-          debug %Q|  #{color(name, GREEN, true)} #{colorize_logging ? "\e[2m#{search}\e[0m" : search}|
+          debug %Q|  #{color(name, GREEN, bold: true)} #{colorize_logging ? "\e[2m#{search}\e[0m" : search}|
         end
       end
 


### PR DESCRIPTION
Resolves:

Rails -- DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. `color("my text", :red, bold: true)`).